### PR TITLE
Replace booleans with `dark` | `light` strings

### DIFF
--- a/.changeset/shiny-onions-share.md
+++ b/.changeset/shiny-onions-share.md
@@ -1,0 +1,5 @@
+---
+'mode-watcher': patch
+---
+
+Change persistent stores to use `dark` | `light` strings instead of booleans

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { getSystemPrefersMode, setInitialClassState, setCurrentMode } from './mode.js';
+	import { getSystemPrefersMode, setInitialClassState, setActiveMode } from './mode.js';
 
 	onMount(() => {
 		if (!('mode' in localStorage)) {
-			setCurrentMode(getSystemPrefersMode());
+			setActiveMode(getSystemPrefersMode());
 		}
 	});
 </script>

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { getModeOsPrefers, setInitialClassState, setModeCurrent } from './mode.js';
+	import { getSystemPrefersMode, setInitialClassState, setCurrentMode } from './mode.js';
 
 	onMount(() => {
-		if (!('modeCurrent' in localStorage)) {
-			setModeCurrent(getModeOsPrefers());
+		if (!('mode' in localStorage)) {
+			setCurrentMode(getSystemPrefersMode());
 		}
 	});
 </script>

--- a/src/lib/mode.ts
+++ b/src/lib/mode.ts
@@ -1,29 +1,25 @@
 // Modified version of the light switch by: https://skeleton.dev
 
-import { derived } from 'svelte/store';
 import { persisted } from 'svelte-persisted-store';
 
 /**
  * Stores
  */
 
-const modeOsPrefers = persisted<'light' | 'dark'>('modeOsPrefers', 'dark');
-const modeUserPrefers = persisted<'light' | 'dark' | undefined>('modeUserPrefers', undefined);
-const modeCurrent = persisted<'light' | 'dark'>('modeCurrent', 'dark');
-
-/** Derived store with either `"light"` or `"dark"` depending on the current mode */
-export const mode = derived(modeCurrent, ($modeCurrent) => $modeCurrent);
+const systemPrefersMode = persisted<'dark' | 'light'>('systemPrefersMode', 'dark');
+const userPrefersMode = persisted<'dark' | 'light' | undefined>('userPrefersMode', undefined);
+export const mode = persisted<'dark' | 'light'>('mode', 'dark');
 
 /**
  * Getters
  */
 
-/** Get the OS preference */
-export function getModeOsPrefers(): 'light' | 'dark' {
+/** Get the operating system preference */
+export function getSystemPrefersMode(): 'dark' | 'light' {
 	const prefersLightMode = window.matchMedia('(prefers-color-scheme: light)').matches
 		? 'light'
 		: 'dark';
-	modeOsPrefers.set(prefersLightMode);
+	systemPrefersMode.set(prefersLightMode);
 	return prefersLightMode;
 }
 
@@ -32,23 +28,23 @@ export function getModeOsPrefers(): 'light' | 'dark' {
  */
 
 /** Set the user preference */
-function setModeUserPrefers(value: 'light' | 'dark' | undefined): void {
-	modeUserPrefers.set(value);
+function setUserPrefersMode(value: 'dark' | 'light' | undefined): void {
+	userPrefersMode.set(value);
 }
 
 /** Set the current mode */
-export function setModeCurrent(value: 'light' | 'dark'): void {
+export function setCurrentMode(value: 'dark' | 'light'): void {
 	const htmlEl = document.documentElement;
 
 	if (value === 'light') {
 		htmlEl.classList.remove('dark');
 		htmlEl.style.colorScheme = 'light';
-	}
-	if (value === 'dark') {
+	} else {
 		htmlEl.classList.add('dark');
 		htmlEl.style.colorScheme = 'dark';
 	}
-	modeCurrent.set(value);
+
+	mode.set(value);
 }
 
 /**
@@ -56,56 +52,59 @@ export function setModeCurrent(value: 'light' | 'dark'): void {
  */
 
 /**
- * Set the visible light/dark mode on page load
+ * Set light/dark class based on user/system preference
+ *
+ * Should be added to <head> to prevent FOUC
  *
  * This function needs to be able to be stringified and thus it cannot use other functions
  */
 export function setInitialClassState() {
 	const htmlEl = document.documentElement;
 
-	const userPrefersMode = localStorage.getItem('modeUserPrefers');
-
-	const systemPrefersMode = window.matchMedia('(prefers-color-scheme: light)').matches
-		? 'light'
-		: 'dark';
-
-	if (userPrefersMode === 'dark' || systemPrefersMode === 'dark') {
-		htmlEl.classList.add('dark');
-		htmlEl.style.colorScheme = 'dark';
+	let userPref: string | null = null;
+	try {
+		userPref = JSON.parse(localStorage.getItem('userPrefersMode') || 'null');
+	} catch {
+		// ignore JSON parsing errors
 	}
 
-	if (userPrefersMode === 'light' || systemPrefersMode === 'light') {
+	const systemPref = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+
+	if (userPref === 'light' || (userPref === null && systemPref === 'light')) {
 		htmlEl.classList.remove('dark');
 		htmlEl.style.colorScheme = 'light';
+	} else {
+		htmlEl.classList.add('dark');
+		htmlEl.style.colorScheme = 'dark';
 	}
 }
 
 /** Toggle between light and dark mode */
 export function toggleMode(): void {
-	modeCurrent.update((curr) => {
-		const next = curr === 'light' ? 'dark' : 'light';
-		setModeUserPrefers(next);
-		setModeCurrent(next);
+	mode.update((curr) => {
+		const next = curr === 'dark' ? 'light' : 'dark';
+		setUserPrefersMode(next);
+		setCurrentMode(next);
 		return next;
 	});
 }
 
 /** Set the mode to light or dark */
-export function setMode(mode: 'light' | 'dark'): void {
-	modeCurrent.update((curr) => {
-		if (curr === mode) return curr;
-		setModeUserPrefers(mode);
-		setModeCurrent(mode);
-		return mode;
+export function setMode(next: 'dark' | 'light'): void {
+	mode.update((curr) => {
+		if (curr === next) return curr;
+		setUserPrefersMode(next);
+		setCurrentMode(next);
+		return next;
 	});
 }
 
-/** Reset the mode to OS preference */
+/** Reset the mode to operating system preference */
 export function resetMode(): void {
-	modeCurrent.update(() => {
-		setModeUserPrefers(undefined);
-		const next = getModeOsPrefers();
-		setModeCurrent(next);
+	mode.update(() => {
+		setUserPrefersMode(undefined);
+		const next = getSystemPrefersMode();
+		setCurrentMode(next);
 		return next;
 	});
 }

--- a/src/lib/mode.ts
+++ b/src/lib/mode.ts
@@ -1,6 +1,7 @@
 // Modified version of the light switch by: https://skeleton.dev
 
 import { persisted } from 'svelte-persisted-store';
+import { readonly } from 'svelte/store';
 
 /**
  * Stores
@@ -8,7 +9,10 @@ import { persisted } from 'svelte-persisted-store';
 
 const systemPrefersMode = persisted<'dark' | 'light'>('systemPrefersMode', 'dark');
 const userPrefersMode = persisted<'dark' | 'light' | undefined>('userPrefersMode', undefined);
-export const mode = persisted<'dark' | 'light'>('mode', 'dark');
+const activeMode = persisted<'dark' | 'light'>('mode', 'dark');
+
+/** Readonly store with either `"light"` or `"dark"` depending on the active mode */
+export const mode = readonly(activeMode);
 
 /**
  * Getters
@@ -32,8 +36,8 @@ function setUserPrefersMode(value: 'dark' | 'light' | undefined): void {
 	userPrefersMode.set(value);
 }
 
-/** Set the current mode */
-export function setCurrentMode(value: 'dark' | 'light'): void {
+/** Set the active mode */
+export function setActiveMode(value: 'dark' | 'light'): void {
 	const htmlEl = document.documentElement;
 
 	if (value === 'light') {
@@ -44,7 +48,7 @@ export function setCurrentMode(value: 'dark' | 'light'): void {
 		htmlEl.style.colorScheme = 'dark';
 	}
 
-	mode.set(value);
+	activeMode.set(value);
 }
 
 /**
@@ -81,30 +85,30 @@ export function setInitialClassState() {
 
 /** Toggle between light and dark mode */
 export function toggleMode(): void {
-	mode.update((curr) => {
+	activeMode.update((curr) => {
 		const next = curr === 'dark' ? 'light' : 'dark';
 		setUserPrefersMode(next);
-		setCurrentMode(next);
+		setActiveMode(next);
 		return next;
 	});
 }
 
 /** Set the mode to light or dark */
-export function setMode(next: 'dark' | 'light'): void {
-	mode.update((curr) => {
-		if (curr === next) return curr;
-		setUserPrefersMode(next);
-		setCurrentMode(next);
-		return next;
+export function setMode(mode: 'dark' | 'light'): void {
+	activeMode.update((curr) => {
+		if (curr === mode) return curr;
+		setUserPrefersMode(mode);
+		setActiveMode(mode);
+		return mode;
 	});
 }
 
 /** Reset the mode to operating system preference */
 export function resetMode(): void {
-	mode.update(() => {
+	activeMode.update(() => {
 		setUserPrefersMode(undefined);
 		const next = getSystemPrefersMode();
-		setCurrentMode(next);
+		setActiveMode(next);
 		return next;
 	});
 }


### PR DESCRIPTION
I could not get #9 to work - ran into some very weird issues.

This patch changes less things, and now all tests pass and it works for apps as well, as far as I can tell.

In this patch:
- I still keep (up to) 3 persistent stores.
- The derived store is no longer needed
- Unused code is removed (`getModeUserPrefers`, `getModeAutoPrefers`, `autoModeWatcher`)
- Variables (and `localStorage` keys) are renamed, mostly to ensure that there are no unforeseen consequences for end users when persistent stores are changed from booleans to strings
- I also fixed the bug mentioned in Discord

All in all, I hope this patch will improve readability