### PR TITLE
Fix bug missing withoutTransition in head

### DIFF
--- a/.changeset/tall-emus-greet.md
+++ b/.changeset/tall-emus-greet.md
@@ -1,0 +1,5 @@
+---
+"mode-watcher": patch
+---
+
+Fix bug missing withoutTransition in head

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -6,7 +6,6 @@
 		setActiveMode,
 		setInitialClassState
 	} from './mode';
-	import { browser } from '$app/environment';
 
 	// track `prefers-color-scheme` if no user preference is set
 	export let track = true;
@@ -34,8 +33,10 @@
 			mql.removeEventListener('change', listener);
 		};
 	});
-
-	if (browser) {
-		setInitialClassState();
-	}
 </script>
+
+<svelte:head>
+	<!-- This causes the new eslint-plugin-svelte: https://github.com/sveltejs/eslint-plugin-svelte/issues/492 -->
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html `<\u{73}cript nonce="%sveltekit.nonce%">(${setInitialClassState.toString()})();</script>`}
+</svelte:head>

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -6,6 +6,7 @@
 		setActiveMode,
 		setInitialClassState
 	} from './mode';
+	import { browser } from '$app/environment';
 
 	// track `prefers-color-scheme` if no user preference is set
 	export let track = true;
@@ -33,10 +34,8 @@
 			mql.removeEventListener('change', listener);
 		};
 	});
-</script>
 
-<svelte:head>
-	<!-- This causes the new eslint-plugin-svelte: https://github.com/sveltejs/eslint-plugin-svelte/issues/492 -->
-	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-	{@html `<\u{73}cript nonce="%sveltekit.nonce%">(${setInitialClassState.toString()})();</script>`}
-</svelte:head>
+	if (browser) {
+		setInitialClassState();
+	}
+</script>

--- a/src/lib/mode.ts
+++ b/src/lib/mode.ts
@@ -71,7 +71,6 @@ export function setActiveMode(value: 'dark' | 'light'): void {
  * This function needs to be able to be stringified and thus it cannot use other functions
  */
 export function setInitialClassState() {
-	withoutTransition(() => {
 		const htmlEl = document.documentElement;
 
 		let userPref: string | null = null;
@@ -95,7 +94,6 @@ export function setInitialClassState() {
 			htmlEl.classList.add('dark');
 			htmlEl.style.colorScheme = 'dark';
 		}
-	});
 }
 
 /** Toggle between light and dark mode */

--- a/src/lib/mode.ts
+++ b/src/lib/mode.ts
@@ -71,29 +71,27 @@ export function setActiveMode(value: 'dark' | 'light'): void {
  * This function needs to be able to be stringified and thus it cannot use other functions
  */
 export function setInitialClassState() {
-		const htmlEl = document.documentElement;
+	const htmlEl = document.documentElement;
 
-		let userPref: string | null = null;
-		try {
-			userPref = JSON.parse(localStorage.getItem('userPrefersMode') || 'system');
-		} catch {
-			// ignore JSON parsing errors
-		}
+	let userPref: string | null = null;
+	try {
+		userPref = JSON.parse(localStorage.getItem('userPrefersMode') || 'system');
+	} catch {
+		// ignore JSON parsing errors
+	}
 
-		const systemPref = window.matchMedia('(prefers-color-scheme: light)').matches
-			? 'light'
-			: 'dark';
+	const systemPref = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
 
-		if (
-			userPref === 'light' ||
-			((userPref === 'system' || userPref === null) && systemPref === 'light')
-		) {
-			htmlEl.classList.remove('dark');
-			htmlEl.style.colorScheme = 'light';
-		} else {
-			htmlEl.classList.add('dark');
-			htmlEl.style.colorScheme = 'dark';
-		}
+	if (
+		userPref === 'light' ||
+		((userPref === 'system' || userPref === null) && systemPref === 'light')
+	) {
+		htmlEl.classList.remove('dark');
+		htmlEl.style.colorScheme = 'light';
+	} else {
+		htmlEl.classList.add('dark');
+		htmlEl.style.colorScheme = 'dark';
+	}
 }
 
 /** Toggle between light and dark mode */


### PR DESCRIPTION
Fix for #28 

When inserting setInitialClassState in svelte:head. it do not import the withoutTransition function. 

at   [line 41 in mode-watcher.svelte
](https://github.com/huntabyte/mode-watcher/blob/2fcc614d470a345031db6b2ccf06490f42b5fc34/src/lib/mode-watcher.svelte#L41C10-L41C10)
```svelte
   {@html `<\u{73}cript nonce="%sveltekit.nonce%">(${setInitialClassState.toString()})();</script>`}
```

### Solution. 
Check if is browser instead and run the function normaly in svelte component