### PR TITLE
add subscribtion to `mode` in `ModeWatcher`

### DIFF
--- a/.changeset/rotten-windows-serve.md
+++ b/.changeset/rotten-windows-serve.md
@@ -1,0 +1,5 @@
+---
+'mode-watcher': patch
+---
+
+Fix bug where mode would not change unless the `mode` store was subscribed to

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { systemPrefersMode, setMode, localStorageKey } from './mode';
+	import { systemPrefersMode, setMode, localStorageKey, mode } from './mode';
 
 	export let track = true;
 
@@ -24,9 +24,14 @@
 	const stringified = setInitialMode.toString();
 
 	onMount(() => {
+		const unsubscriber = mode.subscribe(() => {});
 		systemPrefersMode.tracking(track);
 		systemPrefersMode.query();
 		setMode((localStorage.getItem(localStorageKey) as 'dark' | 'light' | 'system') || 'system');
+
+		return () => {
+			unsubscriber();
+		};
 	});
 </script>
 

--- a/src/tests/StealthMode.svelte
+++ b/src/tests/StealthMode.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { ModeWatcher, toggleMode, setMode, resetMode } from '$lib';
+
+	export let track = true;
+</script>
+
+<ModeWatcher {track} />
+<button on:click={toggleMode} data-testid="toggle"> toggle </button>
+<button on:click={() => setMode('light')} data-testid="light">light</button>
+<button on:click={() => setMode('dark')} data-testid="dark">dark</button>
+<button on:click={() => resetMode()} data-testid="reset">reset</button>

--- a/src/tests/mode.spec.ts
+++ b/src/tests/mode.spec.ts
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/svelte';
 import { expect, it } from 'vitest';
 import Mode from './Mode.svelte';
+import StealthMode from './StealthMode.svelte';
 import userEvent from '@testing-library/user-event';
 import { mediaQueryState } from '../../scripts/setupTest';
 import { tick } from 'svelte';
@@ -231,6 +232,27 @@ it('does not track changes to system preference when track prop is set to false'
 	expect(classes3).toContain('dark');
 	expect(colorScheme3).toBe('dark');
 	expect(mode.textContent).toBe('dark');
+});
+
+it('also works when $mode is not used in the current page', async () => {
+	const { container, getByTestId } = render(StealthMode);
+	const rootEl = container.parentElement;
+
+	const classes = getClasses(rootEl);
+	const colorScheme = getColorScheme(rootEl);
+	expect(classes).toContain('dark');
+	expect(colorScheme).toBe('dark');
+	const toggle = getByTestId('toggle');
+	await userEvent.click(toggle);
+	const classes2 = getClasses(rootEl);
+	const colorScheme2 = getColorScheme(rootEl);
+	expect(classes2).not.toContain('dark');
+	expect(colorScheme2).toBe('light');
+	await userEvent.click(toggle);
+	const classes3 = getClasses(rootEl);
+	const colorScheme3 = getColorScheme(rootEl);
+	expect(classes3).toContain('dark');
+	expect(colorScheme3).toBe('dark');
 });
 
 function getClasses(element: HTMLElement | null): string[] {


### PR DESCRIPTION
this fixes #33 but I am not 100% sure this is the best way. let me know if there is a cleaner solution!

I also added a test the fails before this patch and now works. this tests uses a new test component, `<StealthMode>`, which does not subscribe to `mode` automatically and thus is a better representation for how `mode-watcher` might be used in the wild