### PR TITLE
feat: reduce size of `setInitialMode` to 357 bytes instead of 500 bytes

### DIFF
--- a/.changeset/fresh-pigs-scream.md
+++ b/.changeset/fresh-pigs-scream.md
@@ -1,0 +1,5 @@
+---
+'mode-watcher': patch
+---
+
+reduce size of code used in the <head> tags

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -4,25 +4,6 @@
 
 	export let track = true;
 
-	function setInitialMode() {
-		const htmlEl = document.documentElement;
-
-		const mode = localStorage.getItem('mode') || 'system';
-		const system = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
-
-		if (mode === 'light' || (mode === 'system' && system === 'light')) {
-			htmlEl.classList.remove('dark');
-			htmlEl.style.colorScheme = 'light';
-		} else {
-			htmlEl.classList.add('dark');
-			htmlEl.style.colorScheme = 'dark';
-		}
-
-		localStorage.setItem('mode', mode);
-	}
-
-	const stringified = setInitialMode.toString();
-
 	onMount(() => {
 		const unsubscriber = mode.subscribe(() => {});
 		systemPrefersMode.tracking(track);
@@ -33,6 +14,20 @@
 			unsubscriber();
 		};
 	});
+
+	function setInitialMode() {
+		const e = document.documentElement,
+			m = localStorage.getItem('mode') || 'system',
+			l =
+				m === 'light' ||
+				(m === 'system' && window.matchMedia('(prefers-color-scheme: light)').matches);
+
+		e.classList[l ? 'remove' : 'add']('dark');
+		e.style.colorScheme = l ? 'light' : 'dark';
+		localStorage.setItem('mode', m);
+	}
+
+	const stringified = setInitialMode.toString();
 </script>
 
 <svelte:head>


### PR DESCRIPTION
if I am not mistaken, this code is not minimized.

therefore this patch could make sense - some readability is sacrificed to reduce the amount of bytes transferred to the end user.

it's also possible to optimize this further:
```ts
function setInitialMode(){const e=document.documentElement,t=localStorage.getItem("mode")||"system",o="light"===t||"system"===t&&window.matchMedia("(prefers-color-scheme: light)").matches;e.classList[o?"remove":"add"]("dark"),e.style.colorScheme=o?"light":"dark",localStorage.setItem("mode",t)}
```
but that is really hard to read and only saves 63 bytes. you would also have to add some prettier ignores or something like that, or it would be formatted to be similar to the code used in this patch anyways