### PR TITLE
Add default mode

### DIFF
--- a/.changeset/neat-flowers-begin.md
+++ b/.changeset/neat-flowers-begin.md
@@ -1,0 +1,5 @@
+---
+'mode-watcher': patch
+---
+
+add defaultMode prop

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ The `ModeWatcher` component will automatically detect the user's preferences and
 <ModeWatcher track={false} />
 ```
 
+`ModeWatcher` can also be configured with a default mode instead of automatically detecting the user's preference.
+
+To set a default mode, use the `defaultMode` prop:
+
+```svelte
+<ModeWatcher defaultMode={"dark"}>
+```
+
 ## API
 
 ### toggleMode

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -3,36 +3,32 @@
 	import { systemPrefersMode, setMode, localStorageKey, mode } from './mode';
 
 	export let track = true;
-
-	function setInitialMode() {
-		const htmlEl = document.documentElement;
-
-		const mode = localStorage.getItem('mode') || 'system';
-		const system = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
-
-		if (mode === 'light' || (mode === 'system' && system === 'light')) {
-			htmlEl.classList.remove('dark');
-			htmlEl.style.colorScheme = 'light';
-		} else {
-			htmlEl.classList.add('dark');
-			htmlEl.style.colorScheme = 'dark';
-		}
-
-		localStorage.setItem('mode', mode);
-	}
-
-	const stringified = setInitialMode.toString();
+	export let defaultMode: 'light' | 'dark' | 'system' = 'system';
 
 	onMount(() => {
 		const unsubscriber = mode.subscribe(() => {});
 		systemPrefersMode.tracking(track);
 		systemPrefersMode.query();
-		setMode((localStorage.getItem(localStorageKey) as 'dark' | 'light' | 'system') || 'system');
+		setMode((localStorage.getItem(localStorageKey) as 'dark' | 'light' | 'system') || defaultMode);
 
 		return () => {
 			unsubscriber();
 		};
 	});
+
+	function setInitialMode() {
+		const elem = document.documentElement,
+			mode = localStorage.getItem('mode') || '<DEFAULT_MODE>',
+			light =
+				mode === 'light' ||
+				(mode === 'system' && window.matchMedia('(prefers-color-scheme: light)').matches);
+
+		elem.classList[light ? 'remove' : 'add']('dark');
+		elem.style.colorScheme = light ? 'light' : 'dark';
+		localStorage.setItem('mode', mode);
+	}
+
+	const stringified = setInitialMode.toString().replace('<DEFAULT_MODE>', defaultMode);
 </script>
 
 <svelte:head>


### PR DESCRIPTION
add a default mode prop which is needed in for example https://github.com/melt-ui/melt-ui/pull/738

unfortunately, there are no tests... I tried to add a simple test but it seems like the FOUC prevention code added in the svelte head with:
```svelte
<svelte:head>
	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
	{@html `<script nonce="%sveltekit.nonce%">(` + stringified + `)();</script>`}
</svelte:head>
```
is not used at all in `vitest`? I could comment out things and the (other) tests still passed?

so I am not sure how to deal with that.

what this patch does is it modifies the default value used when no user preference is found in `localStorage` in the FOUC prevention snippet based on the `defaultMode` prop. the snippet will always set `localStorage` to whatever mode it ended up with and this is then read and used in the stores.

I found that this worked well in practice when I tested the `defaultMode` prop.

but it is slightly concerning that the FOUC prevention snippet is not tested at all. I think the "only" reason why the tests work now is because `"system"` is not only the default value of the FOUC prevention snippet code but it also happens to be the default value of the stores themselves. but I'm not sure (as you can tell)

what do you think @huntabyte 